### PR TITLE
Swap to use the new GitHub releases since irssi.org no longer hosts the tarballs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,8 +38,8 @@ RUN buildDeps=' \
 	&& set -x \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/* \
-	&& curl -sSL "http://www.irssi.org/files/irssi-${IRSSI_VERSION}.tar.bz2" -o /tmp/irssi.tar.bz2 \
-	&& curl -sSL "http://www.irssi.org/files/irssi-${IRSSI_VERSION}.tar.bz2.sig" -o /tmp/irssi.tar.bz2.sig \
+	&& curl -fsSL "https://github.com/irssi-import/irssi/releases/download/${IRSSI_VERSION}/irssi-${IRSSI_VERSION}.tar.bz2" -o /tmp/irssi.tar.bz2 \
+	&& curl -fsSL "https://github.com/irssi-import/irssi/releases/download/${IRSSI_VERSION}/irssi-${IRSSI_VERSION}.tar.bz2.sig" -o /tmp/irssi.tar.bz2.sig \
 	&& gpg --verify /tmp/irssi.tar.bz2.sig \
 	&& mkdir -p /usr/src/irssi \
 	&& tar -xjf /tmp/irssi.tar.bz2 -C /usr/src/irssi --strip-components 1 \
@@ -50,7 +50,7 @@ RUN buildDeps=' \
 		--with-bot \
 		--with-proxy \
 		--with-socks \
-	&& make \
+	&& make -j$(nproc) \
 	&& make install \
 	&& rm -rf /usr/src/irssi \
 	&& apt-get purge -y --auto-remove $buildDeps

--- a/update.sh
+++ b/update.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eo pipefail
 
-current="$(curl -fsSL 'http://www.irssi.org/download' | grep '<li>Latest release version: ' | sed -r 's!^.*<li>Latest release version: <strong>([^"]+)</strong></li>.*$!\1!' | head -1)"
+current="$(git ls-remote --tags https://github.com/irssi-import/irssi.git | cut -d/ -f3 | cut -d^ -f1 | sort -uV | grep -v -- -rc | tail -1)"
 
 set -x
 


### PR DESCRIPTION
See https://irssi.org/2015/12/14/irssi-website-now-on-github-pages/ for a little bit more context.
