### PR TITLE
Remove volume definitions.

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -58,7 +58,6 @@ RUN set -x \
 	&& apk del .build-deps
 
 WORKDIR $HOME
-VOLUME $HOME/.irssi
 
 USER user
 CMD ["irssi"]

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -57,7 +57,6 @@ RUN buildDeps=' \
 	&& apt-get purge -y --auto-remove $buildDeps
 
 WORKDIR $HOME
-VOLUME $HOME/.irssi
 
 USER user
 CMD ["irssi"]


### PR DESCRIPTION
I'm proposing we remove the volume definition from the official image. Any images inheriting the image are unable to make any changes to $HOME/.irssi except from a script in the CMD or ENTRYPOINT functions.

jessfraz/irssi#2
docker/docker#3465
docker/docker#3639