### PR TITLE
Add explicit "--build" to our "./configure" invocations

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -16,6 +16,8 @@ RUN set -x \
 	&& apk add --no-cache --virtual .build-deps \
 		autoconf \
 		automake \
+		coreutils \
+		dpkg-dev dpkg \
 		gcc \
 		glib-dev \
 		gnupg \
@@ -28,6 +30,7 @@ RUN set -x \
 		openssl-dev \
 		perl-dev \
 		pkgconf \
+		tar \
 	&& wget "https://github.com/irssi/irssi/releases/download/${IRSSI_VERSION}/irssi-${IRSSI_VERSION}.tar.xz" -O /tmp/irssi.tar.xz \
 	&& wget "https://github.com/irssi/irssi/releases/download/${IRSSI_VERSION}/irssi-${IRSSI_VERSION}.tar.xz.asc" -O /tmp/irssi.tar.xz.asc \
 	&& export GNUPGHOME="$(mktemp -d)" \
@@ -35,18 +38,20 @@ RUN set -x \
 	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 7EE65E3082A5FB06AC7C368D00CCB587DDBEF0E1 \
 	&& gpg --batch --verify /tmp/irssi.tar.xz.asc /tmp/irssi.tar.xz \
 	&& rm -r "$GNUPGHOME" /tmp/irssi.tar.xz.asc \
-	&& mkdir -p /usr/src \
-	&& tar -xJf /tmp/irssi.tar.xz -C /usr/src \
+	&& mkdir -p /usr/src/irssi \
+	&& tar -xf /tmp/irssi.tar.xz -C /usr/src/irssi --strip-components 1 \
 	&& rm /tmp/irssi.tar.xz \
-	&& cd /usr/src/irssi-$IRSSI_VERSION \
+	&& cd /usr/src/irssi \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
 	&& ./configure \
+		--build="$gnuArch" \
 		--enable-true-color \
 		--with-bot \
 		--with-proxy \
 		--with-socks \
-	&& make -j$(getconf _NPROCESSORS_ONLN) \
+	&& make -j "$(nproc)" \
 	&& make install \
-	&& rm -rf /usr/src/irssi-$IRSSI_VERSION \
+	&& rm -rf /usr/src/irssi \
 	&& runDeps="$( \
 		scanelf --needed --nobanner --recursive /usr/local \
 			| awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -22,6 +22,7 @@ RUN buildDeps=' \
 		autoconf \
 		automake \
 		bzip2 \
+		dpkg-dev \
 		libglib2.0-dev \
 		libncurses-dev \
 		libperl-dev \
@@ -46,12 +47,14 @@ RUN buildDeps=' \
 	&& tar -xf /tmp/irssi.tar.xz -C /usr/src/irssi --strip-components 1 \
 	&& rm /tmp/irssi.tar.xz \
 	&& cd /usr/src/irssi \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
 	&& ./configure \
+		--build="$gnuArch" \
 		--enable-true-color \
 		--with-bot \
 		--with-proxy \
 		--with-socks \
-	&& make -j$(nproc) \
+	&& make -j "$(nproc)" \
 	&& make install \
 	&& rm -rf /usr/src/irssi \
 	&& apt-get purge -y --auto-remove $buildDeps


### PR DESCRIPTION
This is tested successfully on amd64 and s390x. :metal:

This is along the same lines as (and is part of some on-going work to get multiarch going for _reals_):

- https://github.com/docker-library/php/pull/429
- https://github.com/docker-library/postgres/pull/284
- https://github.com/docker-library/python/pull/198
- https://github.com/docker-library/ruby/pull/127
- https://github.com/docker-library/tomcat/pull/70
- https://github.com/docker-library/memcached/pull/13
- https://github.com/tianon/docker-bash/pull/3

Also, shrink the diff between the variants:

```diff
diff --git a/alpine/Dockerfile b/debian/Dockerfile
index 7140516..a2dd4c5 100644
--- a/alpine/Dockerfile
+++ b/debian/Dockerfile
@@ -1,10 +1,16 @@
-FROM alpine:3.5
+FROM debian:jessie

-RUN apk --no-cache add \
-       ca-certificates
+RUN apt-get update && apt-get install -y --no-install-recommends \
+               ca-certificates \
+               libdatetime-perl \
+               libglib2.0-0 \
+               libwww-perl \
+               perl \
+               wget \
+       && rm -rf /var/lib/apt/lists/*

 ENV HOME /home/user
-RUN adduser -u 1001 -D user \
+RUN useradd --create-home --home-dir $HOME user \
        && mkdir -p $HOME/.irssi \
        && chown -R user:user $HOME

@@ -12,25 +18,24 @@ ENV LANG C.UTF-8

 ENV IRSSI_VERSION 1.0.2

-RUN set -x \
-       && apk add --no-cache --virtual .build-deps \
+RUN buildDeps=' \
                autoconf \
                automake \
-               coreutils \
-               dpkg-dev dpkg \
-               gcc \
-               glib-dev \
-               gnupg \
-               libc-dev \
+               bzip2 \
+               dpkg-dev \
+               libglib2.0-dev \
+               libncurses-dev \
+               libperl-dev \
+               libssl-dev \
                libtool \
                lynx \
                make \
-               ncurses-dev \
-               openssl \
-               openssl-dev \
-               perl-dev \
-               pkgconf \
-               tar \
+               pkg-config \
+               xz-utils \
+       ' \
+       && set -x \
+       && apt-get update && apt-get install -y $buildDeps --no-install-recommends \
+       && rm -rf /var/lib/apt/lists/* \
        && wget "https://github.com/irssi/irssi/releases/download/${IRSSI_VERSION}/irssi-${IRSSI_VERSION}.tar.xz" -O /tmp/irssi.tar.xz \
        && wget "https://github.com/irssi/irssi/releases/download/${IRSSI_VERSION}/irssi-${IRSSI_VERSION}.tar.xz.asc" -O /tmp/irssi.tar.xz.asc \
        && export GNUPGHOME="$(mktemp -d)" \
@@ -52,15 +57,7 @@ RUN set -x \
        && make -j "$(nproc)" \
        && make install \
        && rm -rf /usr/src/irssi \
-       && runDeps="$( \
-               scanelf --needed --nobanner --recursive /usr/local \
-                       | awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
-                       | sort -u \
-                       | xargs -r apk info --installed \
-                       | sort -u \
-       )" \
-       && apk add --no-cache --virtual .irssi-rundeps $runDeps perl-libwww \
-       && apk del .build-deps
+       && apt-get purge -y --auto-remove $buildDeps

 WORKDIR $HOME

```