### PR TITLE
Add official multiarch support in "generate-stackbrew-library.sh"!

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -28,6 +28,22 @@ dirCommit() {
 	)
 }
 
+getArches() {
+	local repo="$1"; shift
+	local officialImagesUrl='https://github.com/docker-library/official-images/raw/master/library/'
+
+	eval "declare -g -A parentRepoToArches=( $(
+		find -name 'Dockerfile' -exec awk '
+				toupper($1) == "FROM" && $2 !~ /^('"$repo"'|scratch|microsoft\/[^:]+)(:|$)/ {
+					print "'"$officialImagesUrl"'" $2
+				}
+			' '{}' + \
+			| sort -u \
+			| xargs bashbrew cat --format '[{{ .RepoName }}:{{ .TagName }}]="{{ join " " .TagEntry.Architectures }}"'
+	) )"
+}
+getArches 'irssi'
+
 cat <<-EOH
 # this file is generated via https://github.com/jessfraz/irssi/blob/$(fileCommit "$self")/$self
 
@@ -65,9 +81,13 @@ for variant in debian alpine; do
 		variantAliases=( "${versionAliases[@]}" )
 	fi
 
+	parent="$(awk 'toupper($1) == "FROM" { print $2 }' "$variant/Dockerfile")"
+	arches="${parentRepoToArches[$parent]}"
+
 	echo
 	cat <<-EOE
 		Tags: $(join ', ' "${variantAliases[@]}")
+		Architectures: $(join ', ' $arches)
 		GitCommit: $commit
 		Directory: $variant
 	EOE


### PR DESCRIPTION
See also https://github.com/docker-library/buildpack-deps/pull/59, https://github.com/docker-library/golang/pull/163, https://github.com/docker-library/docker/pull/63, and of course, https://github.com/docker-library/official-images/pull/3031 (multiarch, reproducible `debian`!)

Example output (currently):

```console
$ ./generate-stackbrew-library.sh
# this file is generated via https://github.com/jessfraz/irssi/blob/17ac07081475d8061d3a2b3be97bff8a40bc8fcb/generate-stackbrew-library.sh

Maintainers: Jessie Frazelle <acidburn@google.com> (@jessfraz),
             Tianon Gravi <admwiggin@gmail.com> (@tianon)
GitRepo: https://github.com/jessfraz/irssi.git

Tags: 1.0.3, 1.0, 1, latest
Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
GitCommit: f84fa44e38f6955823b76e86477ef5c0e3482301
Directory: debian

Tags: 1.0.3-alpine, 1.0-alpine, 1-alpine, alpine
Architectures: amd64
GitCommit: f84fa44e38f6955823b76e86477ef5c0e3482301
Directory: alpine
```