### PR TITLE
Update Alpine to 3.6

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.6
 
 RUN apk --no-cache add \
 	ca-certificates


### PR DESCRIPTION
No issues were found while building from Alpine 3.6.2