### PR TITLE
Adjust scanelf to properly detect runDeps

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -53,11 +53,10 @@ RUN set -x \
 	&& make install \
 	&& rm -rf /usr/src/irssi \
 	&& runDeps="$( \
-		scanelf --needed --nobanner --recursive /usr/local \
-			| awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
+		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \
+			| tr ',' '\n' \
 			| sort -u \
-			| xargs -r apk info --installed \
-			| sort -u \
+			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
 	)" \
 	&& apk add --no-cache --virtual .irssi-rundeps $runDeps perl-libwww \
 	&& apk del .build-deps


### PR DESCRIPTION
Copying the improvement from https://github.com/docker-library/ruby/pull/161.  Should be no discernible change in packages installed, but does make the sub-shell a little easier to understand.