### PR TITLE
Add initial ".travis.yml"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,41 @@
+language: bash
+services: docker
+
+env:
+  - VARIANT=debian
+  - VARIANT=alpine
+  - VARIANT=debian ARCH=i386
+  - VARIANT=alpine ARCH=i386
+
+install:
+  - git clone https://github.com/docker-library/official-images.git ~/official-images
+
+before_script:
+  - env | sort
+  - wget -qO- 'https://github.com/tianon/pgp-happy-eyeballs/raw/master/hack-my-builds.sh' | bash
+  - cd "$VARIANT"
+  - image="irssi:$VARIANT"
+  - |
+    (
+      set -Eeuo pipefail
+      set -x
+      if [ -n "${ARCH:-}" ]; then
+          from="$(awk '$1 == toupper("FROM") { print $2 }' Dockerfile)"
+          docker pull "$ARCH/$from"
+          docker tag "$ARCH/$from" "$from"
+      fi
+    )
+
+script:
+  - |
+    (
+      set -Eeuo pipefail
+      set -x
+      docker build -t "$image" .
+      ~/official-images/test/run.sh "$image"
+    )
+
+after_script:
+  - docker images
+
+# vim:set et ts=2 sw=2:

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -37,6 +37,7 @@ RUN set -x \
 # gpg: key DDBEF0E1: public key "The Irssi project <staff@irssi.org>" imported
 	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 7EE65E3082A5FB06AC7C368D00CCB587DDBEF0E1 \
 	&& gpg --batch --verify /tmp/irssi.tar.xz.asc /tmp/irssi.tar.xz \
+	&& gpgconf --kill all \
 	&& rm -rf "$GNUPGHOME" /tmp/irssi.tar.xz.asc \
 	&& mkdir -p /usr/src/irssi \
 	&& tar -xf /tmp/irssi.tar.xz -C /usr/src/irssi --strip-components 1 \


### PR DESCRIPTION
This does a build test of both Debian and Alpine on amd64 and i386 (which is a very rough "does multi-arch work?" smoke test).

This also adds `gpgconf --kill all` on Alpine and pgp-happy-eyeballs (see docker-library/php#666 and https://github.com/tianon/pgp-happy-eyeballs) in Travis to help cut down on GPG-related failures.

@jessfraz any chance of enabling Travis for this repo? :innocent: