### PR TITLE
Remove explicit `dirmngr` reference

### DIFF
--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -27,7 +27,6 @@ RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
 		bzip2 \
-		dirmngr \
 		gnupg \
 		libglib2.0-dev \
 		libncurses-dev \


### PR DESCRIPTION
This is pulled in automatically via `gnupg`, and moved from `Recommends` to `Depends` in https://salsa.debian.org/debian/gnupg2/-/commit/99474ad900a8bcdd0e7b68f986fec0013fc01470, which has been part of `src:gnupg2` since 2.1.21-4 (and every supported version of both Debian _and_ Ubuntu have 2.2.x 😇).