### PR TITLE
Add "suite aliases" ("irssi:bullseye", "irssi:alpine3.17")

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -84,6 +84,14 @@ for variant in debian alpine; do
 	parent="$(awk 'toupper($1) == "FROM" { print $2 }' "$variant/Dockerfile")"
 	arches="${parentRepoToArches[$parent]}"
 
+	suiteAlias="${parent#*:}" # "alpine:3.18" -> "3.18", "debian:bookworm-slim" -> "bookworm-slim"
+	suiteAlias="${suiteAlias%-slim}" # "bookworm-slim" -> "bookworm"
+	if [ "$variant" = 'alpine' ]; then
+		suiteAlias="$variant$suiteAlias" # "3.18" -> "alpine3.18"
+	fi
+	variantAliases+=( "${versionAliases[@]/%/-$suiteAlias}" )
+	variantAliases=( "${variantAliases[@]//latest-/}" )
+
 	echo
 	cat <<-EOE
 		Tags: $(join ', ' "${variantAliases[@]}")


### PR DESCRIPTION
This is useful for the pending upgrade to Debian Bookworm (https://github.com/jessfraz/irssi/pull/31) to give users an easier escape hatch for fixing their deployments before they fix their host (newer libseccomp2, Docker, runc).

<details>
<summary>Diff:</summary>

```diff
$ diff -u <(bashbrew list irssi | cut -d: -f2) <(bashbrew list <(./generate-stackbrew-library.sh) | cut -d: -f2)
--- /dev/fd/63	2023-06-20 17:16:53.486516425 -0700
+++ /dev/fd/62	2023-06-20 17:16:53.486516425 -0700
@@ -2,7 +2,15 @@
 1.4
 1
 latest
+1.4.4-bullseye
+1.4-bullseye
+1-bullseye
+bullseye
 1.4.4-alpine
 1.4-alpine
 1-alpine
 alpine
+1.4.4-alpine3.17
+1.4-alpine3.17
+1-alpine3.17
+alpine3.17

$ diff -u <(bashbrew cat irssi) <(bashbrew cat <(./generate-stackbrew-library.sh))
--- /dev/fd/63	2023-06-20 17:17:18.262730239 -0700
+++ /dev/fd/62	2023-06-20 17:17:18.262730239 -0700
@@ -1,12 +1,12 @@
 Maintainers: Jessie Frazelle <acidburn@google.com> (@jessfraz), Tianon Gravi <admwiggin@gmail.com> (@tianon)
 GitRepo: https://github.com/jessfraz/irssi.git
 
-Tags: 1.4.4, 1.4, 1, latest
+Tags: 1.4.4, 1.4, 1, latest, 1.4.4-bullseye, 1.4-bullseye, 1-bullseye, bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 663b9b815d858c94ae6224183afed602d291587e
 Directory: debian
 
-Tags: 1.4.4-alpine, 1.4-alpine, 1-alpine, alpine
+Tags: 1.4.4-alpine, 1.4-alpine, 1-alpine, alpine, 1.4.4-alpine3.17, 1.4-alpine3.17, 1-alpine3.17, alpine3.17
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 6806daa0d17eae1cd10df10ff3a533d3655ac9f8
 Directory: alpine
```

</details>